### PR TITLE
UI: Set expanding size policy for startup/running status comboboxes

### DIFF
--- a/stacer/Pages/Services/services_page.ui
+++ b/stacer/Pages/Services/services_page.ui
@@ -92,10 +92,22 @@
      </item>
      <item>
       <widget class="QComboBox" name="cmbRunningStatus">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>120</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="sizeAdjustPolicy">

--- a/stacer/Pages/Services/services_page.ui
+++ b/stacer/Pages/Services/services_page.ui
@@ -64,10 +64,22 @@
      </item>
      <item>
       <widget class="QComboBox" name="cmbStartupStatus">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>120</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="sizeAdjustPolicy">


### PR DESCRIPTION
## Description
This PR fixes the issue where `cmbStartupStatus` and `cmbRunningStatus` comboboxes on the Services page had a fixed width and did not expand to fit their content. 

This was particularly problematic for some translations where longer status strings could be cut off or displayed incompletely, making the UI less usable for non-English users.

## Changes
- Set `sizePolicy` to `Expanding` for both comboboxes
- Added `maximumSize` (200px) to prevent excessive stretching
- Kept `minimumSize` (120px) for readability
- Applied same behavior as `cmbStartPage` from Settings page

## Before / After
- **Before:** Comboboxes were fixed at 120px width, cutting off longer status names
- **After:** Comboboxes expand to fit content (up to 200px), improving UX

## Video

**Before**
<video src="https://github.com/user-attachments/assets/1339a81f-1ee9-47d7-a57b-3f73a745174e" controls="controls" muted="muted" style="max-height: 400px;"></video>

**After**
<video src="https://github.com/user-attachments/assets/ef90f2c9-f510-4c4d-89d3-6a9e2b329cf3" controls="controls" muted="muted" style="max-height: 400px;"></video>

