### PR TITLE
UI: Rework scrollbar styling to replace black background in Light/Default Themes

### DIFF
--- a/stacer/static/themes/default/style/style.qss
+++ b/stacer/static/themes/default/style/style.qss
@@ -13,11 +13,11 @@ QScrollBar:vertical {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @buttonBackground;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:vertical {
-    background-color: @globalBackground;
+    background-color: @buttonBackground;
     min-height: 20px;
     border-radius: 2;
 }
@@ -47,11 +47,11 @@ QScrollBar:horizontal {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @buttonBackground;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:horizontal {
-    background-color: @globalBackground;
+    background-color: @buttonBackground;
     min-width: 20px;
     border-radius: 2;
 }

--- a/stacer/static/themes/default/style/style.qss
+++ b/stacer/static/themes/default/style/style.qss
@@ -13,7 +13,7 @@ QScrollBar:vertical {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @globalHoverBackground;
+    background-color: @buttonBackground;
 }
 
 QScrollBar::handle:vertical {
@@ -47,7 +47,7 @@ QScrollBar:horizontal {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @globalHoverBackground;
+    background-color: @buttonBackground;
 }
 
 QScrollBar::handle:horizontal {

--- a/stacer/static/themes/default/style/style.qss
+++ b/stacer/static/themes/default/style/style.qss
@@ -10,15 +10,24 @@ QScrollArea {
 
 QScrollBar:vertical {
     width: 12;
-    margin: 0 0 0 2;
-    border-radius: 2;
-    background-color: transparent;
+    margin: 0;
+    padding: 1 1 1 1;
+    border-radius: 0;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:vertical {
     background-color: @globalBackground;
     min-height: 20px;
     border-radius: 2;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: @buttonHoverBackground;
+}
+
+QScrollBar::handle:vertical:pressed {
+    background-color: @buttonBackground;
 }
 
 QScrollBar::add-line:vertical,
@@ -35,15 +44,24 @@ QScrollBar::sub-page:vertical {
 
 QScrollBar:horizontal {
     height: 12;
-    margin: 2 0 0 0;
-    border-radius: 2;
-    background-color: transparent;
+    margin: 0;
+    padding: 1 1 1 1;
+    border-radius: 0;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:horizontal {
     background-color: @globalBackground;
     min-width: 20px;
     border-radius: 2;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background-color: @buttonHoverBackground;
+}
+
+QScrollBar::handle:horizontal:pressed {
+    background-color: @buttonBackground;
 }
 
 QScrollBar::add-line:horizontal,

--- a/stacer/static/themes/light/style/style.qss
+++ b/stacer/static/themes/light/style/style.qss
@@ -13,11 +13,11 @@ QScrollBar:vertical {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @buttonBackground;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:vertical {
-    background-color: @globalBackground;
+    background-color: @buttonBackground;
     min-height: 20px;
     border-radius: 2;
 }
@@ -47,11 +47,11 @@ QScrollBar:horizontal {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @buttonBackground;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:horizontal {
-    background-color: @globalBackground;
+    background-color: @buttonBackground;
     min-width: 20px;
     border-radius: 2;
 }

--- a/stacer/static/themes/light/style/style.qss
+++ b/stacer/static/themes/light/style/style.qss
@@ -13,7 +13,7 @@ QScrollBar:vertical {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @globalHoverBackground;
+    background-color: @buttonBackground;
 }
 
 QScrollBar::handle:vertical {
@@ -47,7 +47,7 @@ QScrollBar:horizontal {
     margin: 0;
     padding: 1 1 1 1;
     border-radius: 0;
-    background-color: @globalHoverBackground;
+    background-color: @buttonBackground;
 }
 
 QScrollBar::handle:horizontal {

--- a/stacer/static/themes/light/style/style.qss
+++ b/stacer/static/themes/light/style/style.qss
@@ -10,15 +10,24 @@ QScrollArea {
 
 QScrollBar:vertical {
     width: 12;
-    margin: 0 0 0 2;
-    border-radius: 2;
-    background-color: transparent;
+    margin: 0;
+    padding: 1 1 1 1;
+    border-radius: 0;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:vertical {
     background-color: @globalBackground;
     min-height: 20px;
     border-radius: 2;
+}
+
+QScrollBar::handle:vertical:hover {
+    background-color: @buttonHoverBackground;
+}
+
+QScrollBar::handle:vertical:pressed {
+    background-color: @buttonBackground;
 }
 
 QScrollBar::add-line:vertical,
@@ -35,15 +44,24 @@ QScrollBar::sub-page:vertical {
 
 QScrollBar:horizontal {
     height: 12;
-    margin: 2 0 0 0;
-    border-radius: 2;
-    background-color: transparent;
+    margin: 0;
+    padding: 1 1 1 1;
+    border-radius: 0;
+    background-color: @globalHoverBackground;
 }
 
 QScrollBar::handle:horizontal {
     background-color: @globalBackground;
     min-width: 20px;
     border-radius: 2;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background-color: @buttonHoverBackground;
+}
+
+QScrollBar::handle:horizontal:pressed {
+    background-color: @buttonBackground;
 }
 
 QScrollBar::add-line:horizontal,


### PR DESCRIPTION
## Description
This PR reworks the scrollbar styling for the Light/Default Themes to fix several visual issues:
- Replaces the black/transparent background with a proper light grey color
- Removes the black border/line that appeared around scrollbars
- Adds hover and pressed states for the scrollbar handle (thumb) for better UX

## Changes
- **Background:** Changed from `transparent` to `@globalHoverBackground` (#ecf0f1) for both vertical and horizontal scrollbars
- **Margins/Padding:** Removed left margin and added consistent padding for better alignment
- **Border-radius:** Set to `0` for the scrollbar groove to avoid visual artifacts
- **Handle interactions:** Added `:hover` and `:pressed` states using button theme colors (`@buttonHoverBackground` and `@buttonBackground`)

## Before & After
**Before**
<video src="https://github.com/user-attachments/assets/395e6146-d66b-418f-8713-e0003872323c" controls="controls" muted="muted" style="max-height: 400px;"></video>

**After**
<video src="https://github.com/user-attachments/assets/39abbc67-4d21-4c2d-bd05-18aae0e36f94" controls="controls" muted="muted" style="max-height: 400px;"></video>

