### PR TITLE
UI: Fix combobox dropdown text color for Light and Default themes (fixes #46)

### DIFF
--- a/stacer/static/themes/default/style/style.qss
+++ b/stacer/static/themes/default/style/style.qss
@@ -283,7 +283,10 @@ QComboBox::down-arrow:on {
 
 QComboBox QAbstractItemView {
     background-color: @globalBackground;
+    color: @globalText;
     border: 0;
+    selection-background-color: @globalHoverBackground;
+    selection-color: @globalText;
 }
 
 /***************

--- a/stacer/static/themes/light/style/style.qss
+++ b/stacer/static/themes/light/style/style.qss
@@ -283,7 +283,10 @@ QComboBox::down-arrow:on {
 
 QComboBox QAbstractItemView {
     background-color: @globalBackground;
+    color: @globalText;
     border: 0;
+    selection-background-color: @globalHoverBackground;
+    selection-color: @globalText;
 }
 
 /***************


### PR DESCRIPTION
Fixes #46.

Explicitly sets text and selection colors for `QComboBox` dropdown items (`QAbstractItemView`) in both Light and Default themes. This prevents the dropdown text from using system defaults, which caused white-on-white text in Light theme on some DEs (e.g., KDE with dark system theme).

**Changes:**
- `color: @globalText`
- `selection-background-color: @globalHoverBackground`
- `selection-color: @globalText`

## Screenshots
**System light theme + Stacer default theme**
<img width="1311" height="600" alt="изображение" src="https://github.com/user-attachments/assets/d66fe56e-eee2-45c0-a15d-970633ca91df" />
**System dark theme + Stacer light theme**
<img width="1294" height="602" alt="изображение" src="https://github.com/user-attachments/assets/46857e54-1dd0-49bf-ac04-59dc11a7d44a" />
