### PR TITLE
fix: Make "%CPU" column header translatable

### DIFF
--- a/stacer/Pages/Processes/processes_page.cpp
+++ b/stacer/Pages/Processes/processes_page.cpp
@@ -27,7 +27,7 @@ void ProcessesPage::init()
 {
     mHeaders = QStringList {
         "PID", tr("Resident Memory"), tr("%Memory"), tr("Virtual Memory"),
-        tr("User"), "%CPU", tr("Start Time"), tr("State"), tr("Group"),
+        tr("User"), tr("%CPU"), tr("Start Time"), tr("State"), tr("Group"),
         tr("Nice"), tr("CPU Time"), tr("Session"), tr("Process")
     };
 


### PR DESCRIPTION
This PR makes the "%CPU" column header in the process table translatable.

**Testing:**
I verified the changes locally:
1. Ran `lupdate` to update the translation (`.ts`) files.
2. Added a Russian translation for this string in `stacer_ru.ts`.
3. Built the application locally.

**Note:**
This commit does **not** include the updated `.ts` files to avoid merge conflicts with the automated Crowdin PR (#43).

<img width="980" height="374" alt="Снимок экрана_20260822_164353" src="https://github.com/user-attachments/assets/7f493a53-a12f-43b6-b1d8-1719ddb1e0b4" />