### PR TITLE
Add Nix flake packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788531059,
+        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,49 +5,65 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    system = "x86_64-linux";
-    pkgs = import nixpkgs {inherit system;};
-  in {
-  packages.${system}.default = pkgs.stdenv.mkDerivation {
-        pname = "stacer";
-        version = "1.7.0";
-
-        src = ./.;
-        #hardeningDisable = [ "fortify" ];
-
-        nativeBuildInputs = with pkgs; [
-          cmake
-          qt6.qttools
-          pkgs.qt6.wrapQtAppsHook
-        ];
-        buildInputs = [
-          pkgs.qt6.qtbase
-          pkgs.qt6.qtcharts
-        ];
-        cmakeBuildType = "Debug";
-
-        meta = {
-          description = "Linux System Optimizer and Monitoring";
-          mainProgram = "stacer";
-          platforms = pkgs.lib.platforms.linux;
-        };
-      };
-
-      apps.${system}.default = {
-        type = "app";
-        program = "${self.packages.${system}.default}/bin/stacer";
-      };
-    devShells.${system}.default = pkgs.mkShell {
-      packages = with pkgs; [
-        cmake
-        qt6.qttools
-        qt6.qtbase
-        qt6.qtcharts
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
       ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "stacer";
+            version = "1.7.0";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              qt6.qttools
+              qt6.wrapQtAppsHook
+            ];
+
+            buildInputs = with pkgs; [
+              qt6.qtbase
+              qt6.qtcharts
+            ];
+
+            cmakeBuildType = "Debug";
+
+            meta = {
+              description = "Linux System Optimizer and Monitoring";
+              mainProgram = "stacer";
+              platforms = pkgs.lib.platforms.linux;
+            };
+          };
+        });
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/stacer";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cmake
+              qt6.qttools
+              qt6.qtbase
+              qt6.qtcharts
+            ];
+          };
+        });
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "flake for stacer";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system;};
+  in {
+  packages.${system}.default = pkgs.stdenv.mkDerivation {
+        pname = "stacer";
+        version = "1.7.0";
+
+        src = ./.;
+        #hardeningDisable = [ "fortify" ];
+
+        nativeBuildInputs = with pkgs; [
+          cmake
+          qt6.qttools
+          pkgs.qt6.wrapQtAppsHook
+        ];
+        buildInputs = [
+          pkgs.qt6.qtbase
+          pkgs.qt6.qtcharts
+        ];
+        cmakeBuildType = "Debug";
+
+        meta = {
+          description = "Linux System Optimizer and Monitoring";
+          mainProgram = "stacer";
+          platforms = pkgs.lib.platforms.linux;
+        };
+      };
+
+      apps.${system}.default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/stacer";
+      };
+    devShells.${system}.default = pkgs.mkShell {
+      packages = with pkgs; [
+        cmake
+        qt6.qttools
+        qt6.qtbase
+        qt6.qtcharts
+      ];
+    };
+  };
+}


### PR DESCRIPTION
This change adds a Nix flake and allows anyone using NixOS or the nix package manager to install Stacer with the command `nix profile add github:QuentiumYT/Stacer`. The flake builds from source and installs Stacer on the users' system.